### PR TITLE
common: bump golang 1.22.7 and bci image 15.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/harvester/networkfs-manager
 
-go 1.22.5
+go 1.22.7
 
 require (
 	github.com/longhorn/longhorn-manager v1.7.0

--- a/package/Dockerfile
+++ b/package/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.7.0
 
-FROM registry.suse.com/bci/bci-base:15.5
+FROM registry.suse.com/bci/bci-base:15.6
 
 RUN zypper -n rm container-suseconnect && \
     zypper -n install util-linux-systemd e2fsprogs iproute2 && \


### PR DESCRIPTION
reference: https://github.com/harvester/harvester/issues/6568

- bump golang 1.22.7
- bump bci image 15.6